### PR TITLE
Introduce `turbo_stream_button_tag` view helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace checks for `nice_partials` with built-in support for capturing the
   `turbo_streams` block
+
+- Introduce the `turbo_stream_button_tag` helper, and replace documented calls
+  to `render("turbo_stream_button")` with calls to `turbo_stream_button_tag`

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ const application = Application.start()
 application.register("turbo-stream-button", TurboStreamButtonController)
 ```
 
-In your Rails templates, render the `turbo_stream_button` view partial to create
-the `<button>` element. The view partial renders:
+In your Rails templates, call the `turbo_stream_button_tag` helper or render the
+`turbo_stream_button` view partial to create the `<button>` element. The view
+partial renders:
 
 * the block content as the `<button>` element's content
 * other keyword arguments as the `<button>` element's attributes
@@ -57,7 +58,7 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
 ### Introductory: Hello, world
 
 ```html+erb
-<%= render "turbo_stream_button", id: "the-button" do |button| %>
+<%= turbo_stream_button_tag id: "the-button" do |button| %>
   <span>Click me to say "hello"</span>
 
   <% button.turbo_streams do %>
@@ -99,8 +100,8 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
 
 <div id="flash" role="alert"></div>
 
-<%= render "turbo_stream_button", value: "invitation-code-abc123",
-                                  data: { controller: "clipboard", action: "click->clipboard#copy" } do |button| %>
+<%= turbo_stream_button_tag value: "invitation-code-abc123",
+                            data: { controller: "clipboard", action: "click->clipboard#copy" } do |button| %>
   Copy to clipboard
 
   <% button.turbo_streams do %>
@@ -132,7 +133,7 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
 ```html+erb
 <div id="flash" role="alert"></div>
 
-<%= render "turbo_stream_button" do |button| %>
+<%= turbo_stream_button_tag do |button| %>
   Append flash message
 
   <% button.turbo_streams do %>
@@ -141,7 +142,7 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
         <div id="a_flash_message" role="status">
           Hello, world!
 
-          <%= render "turbo_stream_button" do |button| %>
+          <%= turbo_stream_button_tag do |button| %>
             Dismiss
 
             <% button.turbo_streams do %>
@@ -217,7 +218,7 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
     <ol id="references"></ol>
 
     <%= form.fields :reference_attributes, index: "{{counter}}" do |reference_form| %>
-      <%= render "turbo_stream_button" do |button| %>
+      <%= turbo_stream_button_tag do |button| %>
         Add reference
 
         <% button.turbo_streams do %>

--- a/app/helpers/turbo_stream_button/helpers.rb
+++ b/app/helpers/turbo_stream_button/helpers.rb
@@ -1,0 +1,5 @@
+module TurboStreamButton::Helpers
+  def turbo_stream_button_tag(**attributes, &block)
+    render("turbo_stream_button", **attributes, &block)
+  end
+end

--- a/lib/turbo_stream_button/engine.rb
+++ b/lib/turbo_stream_button/engine.rb
@@ -7,5 +7,11 @@ module TurboStreamButton
         ]
       end
     end
+
+    initializer "turbo_stream_button.action_view" do |app|
+      ActiveSupport.on_load :action_view do
+        include TurboStreamButton::Helpers
+      end
+    end
   end
 end

--- a/test/integration/examples_test.rb
+++ b/test/integration/examples_test.rb
@@ -58,4 +58,22 @@ class ExamplesTest < ActionDispatch::IntegrationTest
       assert_equal "click->turbo-stream-button#evaluate click->my-controller#action", button["data-action"]
     end
   end
+
+  test "turbo_stream_button_tag supports a block" do
+    post examples_path, params: {template: <<~ERB}
+      <%= turbo_stream_button_tag(data: { action: "click->my-controller#action" }) do |button| %>
+        A button
+
+        <% button.turbo_streams do %>
+          A turbo stream
+        <% end %>
+      <% end %>
+    ERB
+
+    assert_button("A button", type: "button") do |button|
+      assert_equal "click->turbo-stream-button#evaluate click->my-controller#action", button["data-action"]
+    end
+    assert_css(%(template[data-turbo-stream-button-target~="turboStreams"]), visible: :all)
+    assert_equal ["A turbo stream"], response.body.scan(/A turbo stream/)
+  end
 end


### PR DESCRIPTION
Add support for the the `turbo_stream_button_tag` helper. Replace
documented calls to `render("turbo_stream_button")` with calls to
`turbo_stream_button_tag`.