### PR TITLE
Resolve `TurboStreamButton::Helpers` loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Resolve `TurboStreamButton::Helpers` loading issue
+
 ## 0.2.0
 
 ### Changed

--- a/app/helpers/turbo_stream_button/helpers.rb
+++ b/app/helpers/turbo_stream_button/helpers.rb
@@ -1,5 +1,7 @@
-module TurboStreamButton::Helpers
-  def turbo_stream_button_tag(**attributes, &block)
-    render("turbo_stream_button", **attributes, &block)
+module TurboStreamButton
+  module Helpers
+    def turbo_stream_button_tag(**attributes, &block)
+      render("turbo_stream_button", **attributes, &block)
+    end
   end
 end


### PR DESCRIPTION
Addresses errors like:

```
NameError: uninitialized constant TurboStreamButton::Helpers

        include TurboStreamButton::Helpers
                                 ^^^^^^^^^
```

Split `TurboStreamButton::Helpers` definition into a doubly nested
`module`.