### PR TITLE
Support merging multiple tokens in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Support multiple tokens in token list mergers
 - Resolve `TurboStreamButton::Helpers` loading issue
 
 ## 0.2.0

--- a/lib/turbo_stream_button/html.rb
+++ b/lib/turbo_stream_button/html.rb
@@ -3,15 +3,15 @@ module TurboStreamButton
     def self.merge_token_lists(default, override)
       token_list = Set[*override.to_s.split]
 
-      token_list.add(*default.to_s.split)
+      default.to_s.split.each { |token| token_list.add(token) }
 
       token_list.to_a.join(" ")
     end
 
     def self.deep_merge_attributes(default, **attributes)
-      default.deep_merge(attributes) do |key, default, attribute|
+      default.deep_merge(attributes) do |key, default_value, attribute|
         if key.to_s.in? %w[controller action]
-          merge_token_lists(default, attribute)
+          merge_token_lists(default_value, attribute)
         else
           attribute
         end

--- a/test/integration/examples_test.rb
+++ b/test/integration/examples_test.rb
@@ -41,21 +41,21 @@ class ExamplesTest < ActionDispatch::IntegrationTest
 
   test "merges [data-controller] attribute" do
     post examples_path, params: {template: <<~ERB}
-      <%= render "turbo_stream_button", data: { controller: "my-controller" } %>
+      <%= render "turbo_stream_button", data: { controller: "my-controller another-controller" } %>
     ERB
 
     assert_button(type: "button") do |button|
-      assert_equal "turbo-stream-button my-controller", button["data-controller"]
+      assert_equal "turbo-stream-button my-controller another-controller", button["data-controller"]
     end
   end
 
   test "merges [data-action] attribute" do
     post examples_path, params: {template: <<~ERB}
-      <%= render "turbo_stream_button", data: { action: "click->my-controller#action" } %>
+      <%= render "turbo_stream_button", data: { action: "click->my-controller#action click->another-controller#action" } %>
     ERB
 
     assert_button(type: "button") do |button|
-      assert_equal "click->turbo-stream-button#evaluate click->my-controller#action", button["data-action"]
+      assert_equal "click->turbo-stream-button#evaluate click->my-controller#action click->another-controller#action", button["data-action"]
     end
   end
 


### PR DESCRIPTION
Resolves issue where a token list containing multiple tokens was
incorrectly invoking `Set#add`