### PR TITLE
Introduce `Builder` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Introduce `turbo_stream_button` and `turbo_stream_button.template` helpers
+  that know how to render themselves as attributes or elements
+
+      form_with model: Post.new do |form|
+        form.button **turbo_stream_button, type: :submit do
+          turbo_stream_button.template.tag do
+            turbo_stream.append(...)
+          end
+        end
+      end
+
 ### Fixed
 
 - Support multiple tokens in token list mergers

--- a/README.md
+++ b/README.md
@@ -260,6 +260,88 @@ element][mdn-template], activating any `<turbo-stream>` elements nested inside.
         </button> %>
 ```
 
+## Helpers
+
+There are two helpers declared by the engine:
+
+### `turbo_stream_button_tag`
+
+The `turbo_stream_button_tag` helper renders a `<button>` element ready to
+evaluate a collection of `<turbo-stream>` elements:
+
+```erb
+<%= turbo_stream_button_tag do |button| %>
+  Click to append "Hello!"
+
+  <% button.turbo_streams do %>
+    <%= turbo_stream.append_all "body" do %>
+      Hello!
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+### `turbo_stream_button`
+
+The `turbo_stream_button` helper returns an attributes-aware HTML tag builder.
+Render a `<button>` element with the appropriate `[data-controller]` and
+`[data-action]` attributes by calling `#tag`:
+
+```erb
+<%= turbo_stream_button.tag do %>
+  Click to append "Hello!"
+<% end %>
+```
+
+The return a `Hash` of attributes containing the appropriate `[data-controller]`
+and `[data-action]` attributes, call `#merge`, `#to_h` or splat them into
+keyword arguments (with `**`):
+
+```erb
+<%= form_with model: Post.new do |form| %>
+  <%= form.button **turbo_stream_button, type: :submit do %>
+    Click to append "Hello!"
+
+    <%= tag.template turbo_stream_button.template.merge(data: { a_controller_target: "template" }) do %>
+      <%= turbo_stream.append_all "body" do %>
+        Hello!
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+To render the `<template>` element nested within the `<button>`, call
+`#template_tag`:
+
+```erb
+<%= turbo_stream_button.tag do %>
+  Click to append "Hello!"
+
+  <% turbo_stream_button.template_tag do %>
+    <%= turbo_stream.append_all "body" do %>
+      Hello!
+    <% end %>
+  <% end %>
+<% end %>
+```
+
+The return a `Hash` of attributes containing the appropriate
+`[data-turbo-stream-button-target]` attribute, call `#merge`, `#to_h`, or splat
+them into keyword arguments (with `**`):
+
+```erb
+<%= turbo_stream_button.tag do %>
+  Click to append "Hello!"
+
+  <%= tag.template turbo_stream_button.template.merge(data: { a_controller_target: "template" }) do %>
+    <%= turbo_stream.append_all "body" do %>
+      Hello!
+    <% end %>
+  <% end %>
+<% end %>
+```
+
 ## Exploring examples
 
 To poke around with some working examples, start the [dummy application][]

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,14 @@ namespace :test do
   end
 
   desc "Runs all tests, including system tests"
-  task all: %w[test test:system]
+  task all: %w[test:unit test:system]
+
+  desc "Run unit tests only"
+  task :unit do
+    $: << "test"
+
+    Rails::TestUnit::Runner.rake_run(["test"])
+  end
 
   desc "Run system tests only"
   task system: %w[test:prepare] do

--- a/app/helpers/turbo_stream_button/helpers.rb
+++ b/app/helpers/turbo_stream_button/helpers.rb
@@ -1,5 +1,9 @@
 module TurboStreamButton
   module Helpers
+    def turbo_stream_button
+      TurboStreamButton::Button.new(self)
+    end
+
     def turbo_stream_button_tag(**attributes, &block)
       render("turbo_stream_button", **attributes, &block)
     end

--- a/app/views/application/_turbo_stream_button.html.erb
+++ b/app/views/application/_turbo_stream_button.html.erb
@@ -3,11 +3,10 @@
     button = TurboStreamButton::Button.new(self)
 %>
 
-<%= content_tag :button, TurboStreamButton::Html.deep_merge_attributes(attributes, data: {
-      controller: "turbo-stream-button",
-      action: "click->turbo-stream-button#evaluate"
-    }) do %>
+<%= button.tag **attributes do %>
   <%= yield button %>
 
-  <template data-turbo-stream-button-target="turboStreams"><%= button.turbo_streams %></template>
+  <%= button.template_tag do %>
+    <%= button.turbo_streams %>
+  <% end %>
 <% end %>

--- a/lib/turbo_stream_button/builder.rb
+++ b/lib/turbo_stream_button/builder.rb
@@ -1,0 +1,29 @@
+module TurboStreamButton
+  class Builder
+    def initialize(view_context, tag_name, **attributes)
+      @view_context = view_context
+      @tag_name = tag_name
+      @attributes = attributes
+    end
+
+    def tag(*arguments, **overrides, &block)
+      @view_context.content_tag(@tag_name, *arguments, **Html.deep_merge_attributes(overrides, **@attributes), &block)
+    end
+
+    def merge(overrides)
+      Builder.new(@view_context, @tag_name, Html.deep_merge_attributes(overrides, **@attributes))
+    end
+
+    def deep_merge(overrides)
+      merge(overrides)
+    end
+
+    def to_h
+      @attributes.to_h
+    end
+
+    def to_hash
+      @attributes.to_hash
+    end
+  end
+end

--- a/lib/turbo_stream_button/button.rb
+++ b/lib/turbo_stream_button/button.rb
@@ -1,7 +1,20 @@
 module TurboStreamButton
-  class Button
+  class Button < Builder
     def initialize(view_context)
-      @view_context = view_context
+      super(view_context, "button", data: {
+        controller: "turbo-stream-button",
+        action: "click->turbo-stream-button#evaluate"
+      })
+    end
+
+    def template
+      Builder.new(@view_context, "template", data: {
+        turbo_stream_button_target: "turboStreams"
+      })
+    end
+
+    def template_tag(...)
+      template.tag(...)
     end
 
     def turbo_streams(&block)

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <script type="importmap">
       {
         "imports": {
-          "stimulus": "https://cdn.skypack.dev/stimulus",
+          "stimulus": "https://cdn.skypack.dev/stimulus@2.0.0",
           "@hotwired/turbo": "https://cdn.skypack.dev/@hotwired/turbo",
           "@seanpdoyle/turbo_stream_button": "<%= asset_url "turbo_stream_button.js" %>"
         }

--- a/test/integration/examples_test.rb
+++ b/test/integration/examples_test.rb
@@ -76,4 +76,25 @@ class ExamplesTest < ActionDispatch::IntegrationTest
     assert_css(%(template[data-turbo-stream-button-target~="turboStreams"]), visible: :all)
     assert_equal ["A turbo stream"], response.body.scan(/A turbo stream/)
   end
+
+  test "turbo_stream_button merges into other helpers" do
+    post examples_path, params: {template: <<~ERB}
+      <%= form_with url: "/" do |form| %>
+        <%= form.button **turbo_stream_button, type: :submit do %>
+          A button
+
+          <%= tag.template id: "a-template", **turbo_stream_button.template do %>
+            A turbo stream
+          <% end %>
+        <% end %>
+      <% end %>
+    ERB
+
+    assert_button("A button", type: "submit") do |button|
+      assert_equal "turbo-stream-button", button["data-controller"]
+      assert_equal "click->turbo-stream-button#evaluate", button["data-action"]
+    end
+    assert_css(%(template[id="a-template"][data-turbo-stream-button-target~="turboStreams"]), visible: :all)
+    assert_equal ["A turbo stream"], response.body.scan(/A turbo stream/)
+  end
 end


### PR DESCRIPTION
Introduce `turbo_stream_button` and `turbo_stream_button.template`
helpers that know how to render themselves as attributes or elements

```ruby
form_with model: Post.new do |form|
  form.button **turbo_stream_button, type: :submit do
    turbo_stream_button.template.tag do
      turbo_stream.append(...)
    end
  end
end
```

Then, in the original `application/turbo_stream_button` partial, render
the contents in terms of `turbo_stream_button` and
`turbo_stream_button.template`.