### PR TITLE
Qualify `turbo_stream_button_tag` partial name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Qualify call to `render "turbo_stream_button_tag"` with `application/`
+  namespace
+
 ## 0.2.1 (Jan 12, 2023)
 
 - Introduce `turbo_stream_button` and `turbo_stream_button.template` helpers

--- a/lib/turbo_stream_button/helpers.rb
+++ b/lib/turbo_stream_button/helpers.rb
@@ -5,7 +5,7 @@ module TurboStreamButton
     end
 
     def turbo_stream_button_tag(**attributes, &block)
-      render("turbo_stream_button", **attributes, &block)
+      render("application/turbo_stream_button", **attributes, &block)
     end
   end
 end


### PR DESCRIPTION
When rendering into `ActionController:Base` descendants that don't inherit from `ApplicationController`, the bare call to `render "turbo_stream_button_tag"` does not resolve.

By fully qualifying the partial name, the renderer has enough information to resolve the file.