### PR TITLE
Use `declare readonly` to avoid overriding the existing Stimulus property

### DIFF
--- a/packages/turbo_stream_button/turbo_stream_button_controller.ts
+++ b/packages/turbo_stream_button/turbo_stream_button_controller.ts
@@ -3,7 +3,7 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [ "turboStreams" ]
 
-  turboStreamsTargets!: HTMLTemplateElement[]
+  declare turboStreamsTargets: HTMLTemplateElement[]
 
   evaluate({ target }: Event) {
     if (target instanceof Element) {

--- a/packages/turbo_stream_button/turbo_stream_button_controller.ts
+++ b/packages/turbo_stream_button/turbo_stream_button_controller.ts
@@ -3,7 +3,7 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [ "turboStreams" ]
 
-  declare turboStreamsTargets: HTMLTemplateElement[]
+  declare readonly turboStreamsTargets: HTMLTemplateElement[]
 
   evaluate({ target }: Event) {
     if (target instanceof Element) {


### PR DESCRIPTION
This change follows the advice from the Stimulus [reference](https://stimulus.hotwired.dev/reference/using-typescript#define-target-properties) to make sure the property that stimulus creates is not overwritten. 

I found this to be an issue when I encountered the following error:

```
TypeError: this.turboStreamsTargets is not iterable
```

This was working just fine before but became an issue after we started upgrading some packages in our company. I haven't been able to pinpoint exactly what caused the issue though. I should also note, I'm not using this gem or package directly, I just copied the controller to our codebase but thought I opened this PR to help out.