### PR TITLE
Simplify HTML attribute token list merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Expand matrix of supported versions to include `ruby@3.3` and `rails@7.2`.
+- Rely on view context's `#token_list` to merge token lists
 
 ## 0.2.2 (Jan 12, 2023)
 

--- a/lib/turbo_stream_button/builder.rb
+++ b/lib/turbo_stream_button/builder.rb
@@ -7,11 +7,11 @@ module TurboStreamButton
     end
 
     def tag(*arguments, **overrides, &block)
-      @view_context.content_tag(@tag_name, *arguments, **Html.deep_merge_attributes(overrides, **@attributes), &block)
+      @view_context.content_tag(@tag_name, *arguments, **Html.deep_merge_attributes(@view_context, @attributes, overrides), &block)
     end
 
     def merge(overrides)
-      Builder.new(@view_context, @tag_name, Html.deep_merge_attributes(overrides, **@attributes))
+      Builder.new(@view_context, @tag_name, Html.deep_merge_attributes(@view_context, @attributes, overrides))
     end
 
     def deep_merge(overrides)

--- a/lib/turbo_stream_button/html.rb
+++ b/lib/turbo_stream_button/html.rb
@@ -1,17 +1,9 @@
 module TurboStreamButton
-  module Html
-    def self.merge_token_lists(default, override)
-      token_list = Set[*override.to_s.split]
-
-      default.to_s.split.each { |token| token_list.add(token) }
-
-      token_list.to_a.join(" ")
-    end
-
-    def self.deep_merge_attributes(default, **attributes)
+  module Html # :nodoc:
+    def self.deep_merge_attributes(view_context, default, attributes)
       default.deep_merge(attributes) do |key, default_value, attribute|
         if key.to_s.in? %w[controller action]
-          merge_token_lists(default_value, attribute)
+          view_context.token_list(default_value, attribute)
         else
           attribute
         end

--- a/test/integration/examples_test.rb
+++ b/test/integration/examples_test.rb
@@ -49,6 +49,16 @@ class ExamplesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "merges [data-controller] attribute as #token_list arguments" do
+    post examples_path, params: {template: <<~ERB}
+      <%= render "turbo_stream_button", data: { controller: ["my-controller", "another-controller" => true] } %>
+    ERB
+
+    assert_button(type: "button") do |button|
+      assert_equal "turbo-stream-button my-controller another-controller", button["data-controller"]
+    end
+  end
+
   test "merges [data-action] attribute" do
     post examples_path, params: {template: <<~ERB}
       <%= render "turbo_stream_button", data: { action: "click->my-controller#action click->another-controller#action" } %>
@@ -56,6 +66,16 @@ class ExamplesTest < ActionDispatch::IntegrationTest
 
     assert_button(type: "button") do |button|
       assert_equal "click->turbo-stream-button#evaluate click->my-controller#action click->another-controller#action", button["data-action"]
+    end
+  end
+
+  test "merges [data-action] attribute as #token_list arguments" do
+    post examples_path, params: {template: <<~ERB}
+      <%= render "turbo_stream_button", data: { action: ["click->my-controller#a", "click->my-controller#b" => true] } %>
+    ERB
+
+    assert_button(type: "button") do |button|
+      assert_equal "click->turbo-stream-button#evaluate click->my-controller#a click->my-controller#b", button["data-action"]
     end
   end
 


### PR DESCRIPTION
Rely on view context's `#token_list` to merge token lists.

Manipulating the token list manually (through calls to `String#split` and `Array#join`) had the potential to affect
`ActiveSupport::SafeBuffer` HTML safety.

This commit replaces that bespoke logic with calls to [ActionView::Helpers::TagHelper#token_list][] to rely entirely on the view for managing the escaping, safety, and joining of the String values.

[ActionView::Helpers::TagHelper#token_list]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list