### PR TITLE
Drop end-of-life Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         rails-version:
-          - "6.1"
-          - "7.0"
           - "7.1"
           - "7.2"
         include:
           - { ruby-version: "3.2", rails-version: "main" }
           - { ruby-version: "3.3", rails-version: "main" }
-        exclude:
-          - { ruby-version: "2.7", rails-version: "7.1" }
-          - { ruby-version: "2.7", rails-version: "7.2" }
-          - { ruby-version: "3.0", rails-version: "7.2" }
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 2.7
+ruby_version: 3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop [end-of-life Ruby] versions 2.7 and 3.0
+- Drop [end-of-life Rails] versions 6.2 and 7.0
+
+[end-of-life Ruby]: https://www.ruby-lang.org/en/downloads/branches/
+[end-of-lie Rails]: https://rubyonrails.org/maintenance
+
 ## 0.2.3 (Oct 24, 2024)
 
 - Expand matrix of supported versions to include `ruby@3.3` and `rails@7.2`.

--- a/lib/turbo_stream_button/builder.rb
+++ b/lib/turbo_stream_button/builder.rb
@@ -6,8 +6,8 @@ module TurboStreamButton
       @attributes = attributes
     end
 
-    def tag(*arguments, **overrides, &block)
-      @view_context.content_tag(@tag_name, *arguments, **Html.deep_merge_attributes(@view_context, @attributes, overrides), &block)
+    def tag(*arguments, **overrides, &)
+      @view_context.content_tag(@tag_name, *arguments, Html.deep_merge_attributes(@view_context, @attributes, overrides), &)
     end
 
     def merge(overrides)

--- a/lib/turbo_stream_button/helpers.rb
+++ b/lib/turbo_stream_button/helpers.rb
@@ -4,8 +4,8 @@ module TurboStreamButton
       TurboStreamButton::Button.new(self)
     end
 
-    def turbo_stream_button_tag(**attributes, &block)
-      render("application/turbo_stream_button", **attributes, &block)
+    def turbo_stream_button_tag(**attributes, &)
+      render("application/turbo_stream_button", **attributes, &)
     end
   end
 end

--- a/turbo_stream_button.gemspec
+++ b/turbo_stream_button.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |spec|
   spec.description = "Combine built-in Button elements and Turbo Streams to drive client-side interactions through declarative HTML"
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.1.0"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/seanpdoyle/turbo_stream_button"
   spec.metadata["changelog_uri"] = "https://github.com/seanpdoyle/turbo_stream_button/blob/main/CHANGELOG.md"
@@ -18,6 +20,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 6.0"
+  spec.add_dependency "rails", ">= 7.1"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
Drop [end-of-life Ruby] versions 2.7 and 3.0 and [end-of-life Rails] versions 6.2 and 7.0

[end-of-life Ruby]: https://www.ruby-lang.org/en/downloads/branches/
[end-of-lie Rails]: https://rubyonrails.org/maintenance